### PR TITLE
Solves an issue with training custom BPE codes

### DIFF
--- a/codeprep/bpepkg/merge.py
+++ b/codeprep/bpepkg/merge.py
@@ -127,7 +127,7 @@ class MergeList(object):
             merge.priority += first_list_len
             new_merge_list.append(merge)
 
-        return
+        return new_merge_list
 
     def append(self, merge: Merge) -> 'MergeList':
         # along with the pair we save its priority and the number of its occurrences


### PR DESCRIPTION
Hi

First of all, thanks for sharing this useful tool with the research community. 
When I ran the command `codeprep learn-bpe` for training custom BPE codes, I encountered the following exception:
```
Traceback (most recent call last):
  File "/home/amir/py_venv/py_37/bin/codeprep", line 8, in <module>
    sys.exit(main())
  File "/home/amir/py_venv/py_37/lib/python3.7/site-packages/codeprep/__main__.py", line 11, in main
    parse_and_run(sys.argv[1:])
  File "/home/amir/py_venv/py_37/lib/python3.7/site-packages/codeprep/cli/spec.py", line 177, in parse_and_run
    dsc.main(app_name, f'{app_name} {version}', argv=args, exit_at_end=False)
  File "/home/amir/py_venv/py_37/lib/python3.7/site-packages/docopt_subcommands/__init__.py", line 65, in main
    result = commands(argv)
  File "/home/amir/py_venv/py_37/lib/python3.7/site-packages/docopt_subcommands/subcommands.py", line 165, in __call__
    return handler(config)
  File "/home/amir/py_venv/py_37/lib/python3.7/site-packages/codeprep/cli/spec.py", line 173, in bpelearn_handler
    handle_learnbpe(args)
  File "/home/amir/py_venv/py_37/lib/python3.7/site-packages/codeprep/cli/impl.py", line 62, in handle_learnbpe
    bpelearner.run(dataset, n_merges, bpe_config)
  File "/home/amir/py_venv/py_37/lib/python3.7/site-packages/codeprep/pipeline/bpelearner.py", line 110, in run
    new_bpe_dir = os.path.join(dataset_bpe_path, str(len(merges)))
TypeError: object of type 'NoneType' has no len()
```
This error happens when two MergeList objects are added and the result of the addition will be a `None`.
https://github.com/giganticode/codeprep/blob/d42b695c21d6bbe1538a269943ea11839bb66aa0/codeprep/pipeline/bpelearner.py#L108

To reproduce the issue, run the `codeprep learn-bpe` for a corpus.

I have fixed the described issue in this PR.
You might want to review this PR and merge it if possible.